### PR TITLE
Simplify "callers directory" logic by removing inspect in favor of explicit argument

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ build
 dist
 __pycache__
 .coverage
+.vscode
 *.egg-info

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![python](https://github.com/dkmiller/pyconfigurableml/workflows/python/badge.svg)](https://github.com/dkmiller/pyconfigurableml/actions?query=workflow%3Apython)
 [![Coverage Status](https://coveralls.io/repos/github/dkmiller/pyconfigurableml/badge.svg?branch=master)](https://coveralls.io/github/dkmiller/pyconfigurableml?branch=master)
+[![PyPI version](https://badge.fury.io/py/pyconfigurableml.svg)](https://badge.fury.io/py/pyconfigurableml)
+[![PyPI - Downloads](https://img.shields.io/pypi/dm/pyconfigurableml)](https://pypi.org/project/pyconfigurableml/)
 
 Python utilities for easily configurable machine learning.
 
@@ -33,5 +35,3 @@ Calculate and publish code coverage.
 Follow badges at [typeguard](https://github.com/agronholm/typeguard).
 
 - [Coveralls](https://docs.coveralls.io/python)
-- [Pypi badge](https://thomas-cokelaer.info/blog/2014/08/1013/), include
-  number of downloads.

--- a/README.md
+++ b/README.md
@@ -22,16 +22,9 @@ def main(config, log):
 if __name__ == '__main__':
   # The main function will be called with appropriate configuration
   # object and logger.
-  run(main)
+  run(main, __file__)
+
+# Alternative approach. Will only load configuration + run main if
+# __name__ == '__main__'.
+run(main, __file__, __name__)
 ```
-
-## Roadmap
-
-Create and publish a Python package for handling configuration (via config.yml
-or command line args) logging, etc.
-
-Calculate and publish code coverage.
-
-Follow badges at [typeguard](https://github.com/agronholm/typeguard).
-
-- [Coveralls](https://docs.coveralls.io/python)

--- a/pyconfigurableml/entry.py
+++ b/pyconfigurableml/entry.py
@@ -35,8 +35,8 @@ def run(main: Callable[[object, logging.Logger], None],
         parser.add_argument('--level', default='INFO')
         args = parser.parse_args()
 
-        with open(args.config, 'r') as file:
-            config = yaml.safe_load(file)
+        with open(args.config, 'r') as config_file:
+            config = yaml.safe_load(config_file)
 
         logging.basicConfig(level=args.level)
         logger = logging.getLogger()

--- a/pyconfigurableml/entry.py
+++ b/pyconfigurableml/entry.py
@@ -4,7 +4,6 @@ Utilities around programatic entry point.
 
 
 import argparse
-import inspect
 import logging
 import os
 from typing import Callable
@@ -13,31 +12,33 @@ import yaml
 
 
 @typechecked
-def run(main: Callable[[object, logging.Logger], None]) -> None:
+def run(main: Callable[[object, logging.Logger], None],
+        file: str,
+        name: str = '__main__') -> None:
     '''
     Handle log levels and parsing a YAML configuration file. The default
     path to the configuration file is `<caller directory>/config.yml`.
 
-    WARNING: the default configuration file path does not work with decorated
-    functions, i.e. `main` should not be decorated.
+        Parameters:
+            main: programatic entry point for your program.
+            file: should be __file__ in the entry point of your script.
+            name: optionally __name__ in your script. This function will only
+                  call main if __name__ == '__main__'.
     '''
-    # Follow https://stackoverflow.com/a/37792573 to get the caller's file name.
-    stack = inspect.stack()
 
-    # TODO: explicitly exclude anything with typeguard in the name.
-    caller_file = stack[1][1]
-    caller_dir = os.path.dirname(os.path.abspath(caller_file))
+    if name == '__main__':
+        caller_dir = os.path.dirname(os.path.abspath(file))
 
-    parser = argparse.ArgumentParser()
+        parser = argparse.ArgumentParser()
 
-    parser.add_argument('--config', default=os.path.join(caller_dir, 'config.yml'))
-    parser.add_argument('--level', default='INFO')
-    args = parser.parse_args()
+        parser.add_argument('--config', default=os.path.join(caller_dir, 'config.yml'))
+        parser.add_argument('--level', default='INFO')
+        args = parser.parse_args()
 
-    with open(args.config, 'r') as file:
-        config = yaml.safe_load(file)
+        with open(args.config, 'r') as file:
+            config = yaml.safe_load(file)
 
-    logging.basicConfig(level=args.level)
-    logger = logging.getLogger()
+        logging.basicConfig(level=args.level)
+        logger = logging.getLogger()
 
-    main(config, logger)
+        main(config, logger)

--- a/pyconfigurableml/entry.py
+++ b/pyconfigurableml/entry.py
@@ -15,10 +15,15 @@ import yaml
 @typechecked
 def run(main: Callable[[object, logging.Logger], None]) -> None:
     '''
-    Handle log levels and parsing a YAML configuration file.
+    Handle log levels and parsing a YAML configuration file. The default
+    path to the configuration file is `<caller directory>/config.yml`.
+
+    WARNING: the default configuration file path does not work with decorated
+    functions, i.e. `main` should not be decorated.
     '''
     # Follow https://stackoverflow.com/a/37792573 to get the caller's file name.
-    caller_file = inspect.stack()[1][1]
+    stack = inspect.stack()
+    caller_file = stack[1][1]
     caller_dir = os.path.dirname(os.path.abspath(caller_file))
 
     parser = argparse.ArgumentParser()

--- a/pyconfigurableml/entry.py
+++ b/pyconfigurableml/entry.py
@@ -23,6 +23,8 @@ def run(main: Callable[[object, logging.Logger], None]) -> None:
     '''
     # Follow https://stackoverflow.com/a/37792573 to get the caller's file name.
     stack = inspect.stack()
+
+    # TODO: explicitly exclude anything with typeguard in the name.
     caller_file = stack[1][1]
     caller_dir = os.path.dirname(os.path.abspath(caller_file))
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,6 @@ pytest
 pyyaml
 twine
 typeguard
+uuid>=1.30
 # https://stackoverflow.com/a/44862371
 wheel

--- a/setup.py
+++ b/setup.py
@@ -23,4 +23,6 @@ setup(
     packages=['pyconfigurableml'],
     include_package_data=True,
     install_requires=['typeguard>=2.8.0', 'pyyaml>=5.3.0'],
+    # https://stackoverflow.com/a/48777286
+    python_requires='~=3.6',
 )

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ README = (HERE / 'README.md').read_text()
 
 setup(
     name='pyconfigurableml',
-    version='0.0.0',
+    version='0.0.1',
     description='Configurable ML in Python',
     long_description=README,
     long_description_content_type='text/markdown',
@@ -22,5 +22,5 @@ setup(
     ],
     packages=['pyconfigurableml'],
     include_package_data=True,
-    install_requires=['typeguard>=2.8.0', 'pyyaml>=5.3.1'],
+    install_requires=['typeguard>=2.8.0', 'pyyaml>=5.3.0'],
 )

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ README = (HERE / 'README.md').read_text()
 
 setup(
     name='pyconfigurableml',
-    version='0.0.1',
+    version='0.1.0',
     description='Configurable ML in Python',
     long_description=README,
     long_description_content_type='text/markdown',

--- a/tests/test_entry.py
+++ b/tests/test_entry.py
@@ -43,5 +43,7 @@ def test_if_name_not_main_then_not_called():
     '''
     def main(cfg, log):
         raise Exception('I should not be called')
-    with patch( 'argparse.ArgumentParser.parse_args', return_value=None):
-        run(main, __file__, '__not_main__')
+    # https://stackoverflow.com/a/534847
+    file = str(uuid.uuid4())
+    with patch('argparse.ArgumentParser.parse_args', return_value=None):
+        run(main, file, '__not_main__')

--- a/tests/test_entry.py
+++ b/tests/test_entry.py
@@ -3,6 +3,7 @@ import os
 from unittest.mock import patch
 from pyconfigurableml.entry import run
 import pytest
+import uuid
 
 
 @pytest.mark.parametrize('input', [
@@ -12,7 +13,7 @@ import pytest
 ])
 def test_run_type_checking(input) -> None:
     with pytest.raises(TypeError):
-        run(input)
+        run(input, __file__)
 
 
 @pytest.mark.parametrize('config_name,level,called,main', [
@@ -30,5 +31,17 @@ def test_run_config(config_name, level, called, main):
             ):
         # https://stackoverflow.com/a/31756485
         with patch(f'logging.Logger.{level}') as mock_logger:
-            run(main)
+            run(main, __file__)
             mock_logger.assert_called_with(called)
+
+
+def test_if_name_not_main_then_not_called():
+    '''
+    Call `run` on a method which throws an exception, after patching
+    `parse_args` to return None. This verifies no argument parsing is done, and
+    that `main` is not called.
+    '''
+    def main(cfg, log):
+        raise Exception('I should not be called')
+    with patch( 'argparse.ArgumentParser.parse_args', return_value=None):
+        run(main, __file__, '__not_main__')


### PR DESCRIPTION
The logic to inspect the stack trace and find the caller's file did not work when consuming this package. Decorators somehow messed it up.

Version bump is to 0.1 even though this is a breaking change since the version numbers are still in "beta" format (0.&ast;).