### PR TITLE
Add non-command-line mode along with some bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,9 @@ def custom_setup_logic(config, log):
   pass
 
 def setup_module(module):
-  run(custom_setup_logic, __file__)
+  # You probably don't want to attempt to parse command line arguments
+  # inside unit tests.
+  run_no_parse_args(custom_setup_logic, __file__)
 ```
 
 ## Configuring this library

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ You may also use this library to configure a set of unit tests. If you're using
 PyTest, 
 
 ```python
-from pyconfigurableml.entry import run
+from pyconfigurableml.entry import run_no_parse_args
 
 def custom_setup_logic(config, log):
   # TODO: put your logic here.

--- a/pyconfigurableml/entry.py
+++ b/pyconfigurableml/entry.py
@@ -41,9 +41,9 @@ def default_config_path(file: str) -> str:
 
 @typechecked
 def run_no_parse_args(main: Callable[[object, logging.Logger], None],
-        file: str,
-        log_level: str = 'INFO',
-        config_path: str = None) -> None:
+                      file: str,
+                      log_level: str = 'INFO',
+                      config_path: str = None) -> None:
     '''
     Handle log levels and parsing a YAML configuration file, **without**
     attempting to parse any command line arguments. Use `default_config_path`
@@ -68,7 +68,6 @@ def run_no_parse_args(main: Callable[[object, logging.Logger], None],
 
     logger = logging.getLogger()
     main(config, logger)
-
 
 
 @typechecked

--- a/pyconfigurableml/entry.py
+++ b/pyconfigurableml/entry.py
@@ -42,7 +42,6 @@ def default_config_path(file: str) -> str:
 @typechecked
 def run_no_parse_args(main: Callable[[object, logging.Logger], None],
         file: str,
-        name: str,
         log_level: str = 'INFO',
         config_path: str = None) -> None:
     '''
@@ -53,8 +52,6 @@ def run_no_parse_args(main: Callable[[object, logging.Logger], None],
         Parameters:
             main: programatic entry point for your program.
             file: should be __file__ in the entry point of your script.
-            name: optionally __name__ in your script. This function will only
-                  call main if __name__ == '__main__'.
             log_level: base log level.
             config_path: path to configuration object.
     '''
@@ -97,4 +94,4 @@ def run(main: Callable[[object, logging.Logger], None],
         parser.add_argument('--level', default='INFO')
         args = parser.parse_args()
 
-        run_no_parse_args(main, file, name, args.level, args.config)
+        run_no_parse_args(main, file, args.level, args.config)

--- a/pyconfigurableml/files.py
+++ b/pyconfigurableml/files.py
@@ -25,14 +25,17 @@ def download_url_to_file(url: str, path: str) -> None:
     https://stackoverflow.com/a/39217788
     '''
     try:
+        directory = os.path.dirname(path)
+        os.makedirs(directory, exist_ok=True)
         with requests.get(url, stream=True) as req:
             with open(path, 'wb') as file:
                 shutil.copyfileobj(req.raw, file)
 
     # Attempt to clean up:
     # https://stackoverflow.com/a/10840586
-    except:  # noqa: E722
-        log.error(f'Could not download {url} to {path}')
+    except Exception as e:
+        # https://www.loggly.com/blog/exceptional-logging-of-exceptions-in-python/
+        log.exception(f'Could not download {url} to {path}')
         try:
             os.remove(path)
         except OSError:

--- a/pyconfigurableml/files.py
+++ b/pyconfigurableml/files.py
@@ -25,6 +25,7 @@ def download_url_to_file(url: str, path: str) -> None:
     https://stackoverflow.com/a/39217788
     '''
     try:
+        path = os.path.realpath(path)
         directory = os.path.dirname(path)
         os.makedirs(directory, exist_ok=True)
         with requests.get(url, stream=True) as req:
@@ -33,7 +34,7 @@ def download_url_to_file(url: str, path: str) -> None:
 
     # Attempt to clean up:
     # https://stackoverflow.com/a/10840586
-    except Exception as e:
+    except Exception:
         # https://www.loggly.com/blog/exceptional-logging-of-exceptions-in-python/
         log.exception(f'Could not download {url} to {path}')
         try:

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ README = (HERE / 'README.md').read_text()
 
 setup(
     name='pyconfigurableml',
-    version='0.4.0',
+    version='0.5.0',
     description='Configurable ML in Python',
     long_description=README,
     long_description_content_type='text/markdown',
@@ -22,7 +22,7 @@ setup(
     ],
     packages=['pyconfigurableml'],
     include_package_data=True,
-    install_requires=['typeguard>=2.9.1', 'pyyaml>=5.3.1'],
+    install_requires=['typeguard>=2.9.1', 'pyyaml>=5.3.1', 'requests>=2.24.0'],
     # https://setuptools.readthedocs.io/en/latest/setuptools.html#declaring-extras-optional-features-with-their-own-dependencies
     extras_require={
         'azure': ['azure-identity>=1.3.1', 'azure-keyvault-secrets>=4.1.0'],

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,9 @@ setup(
     classifiers=[
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8'
     ],
     packages=['pyconfigurableml'],
     include_package_data=True,

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -9,7 +9,9 @@ from pyconfigurableml.files import (
 
 
 @pytest.mark.parametrize('url,file_name', [
-    ('https://picsum.photos/id/237/200', 'foo.png')
+    ('https://picsum.photos/id/237/200', 'foo.png'),
+    ('https://picsum.photos/id/237/200', 'dir/foo.png'),
+    ('https://picsum.photos/id/237/200', 'a/b/c/foo.png')
 ])
 def test_download_url_to_file(url, file_name, tmpdir):
     path = str(tmpdir.join(file_name))


### PR DESCRIPTION
This pull requests adds a new method `run_no_parse_args` for cases when you **don't** want to read or parse any command-line arguments. It also fixes a couple option issues.

## To-do

- [x] Test via `pip install` from this branch.
- [x] Add example for configuring unit / integration tests.

This closes #8 , closes #11 .
